### PR TITLE
[feat] Update date formatting in Event components to use UTC

### DIFF
--- a/src/Components/Event/EventCard.tsx
+++ b/src/Components/Event/EventCard.tsx
@@ -71,11 +71,11 @@ export function EventCard({ Event }: { Event: Models.IEvent }) {
           </label>
 
           <label className="text-xl font-medium text-slate-700">
-            {dayjs(Event.Start).format("YYYY-MM-DD HH:mm [UTC]")}
+            {dayjs(Event.Start).utc().format("YYYY-MM-DD HH:mm [UTC]")}
           </label>
 
           <label className="text-xl font-medium text-slate-700">
-            {Event.End ? dayjs(Event.End).format("YYYY-MM-DD HH:mm [UTC]") : "Still Ongoing"}
+            {Event.End ? dayjs(Event.End).utc().format("YYYY-MM-DD HH:mm [UTC]") : "Still Ongoing"}
           </label>
         </div>
       </div>

--- a/src/Components/Event/EventLog.tsx
+++ b/src/Components/Event/EventLog.tsx
@@ -41,7 +41,7 @@ export function EventLog({ Event }: { Event: Models.IEvent }) {
                 <label className="font-medium">{history.Status}</label>
 
                 <label>
-                  {dayjs(history.Created).format("YYYY-MM-DD HH:mm [UTC]")}
+                  {dayjs(history.Created).utc().format("YYYY-MM-DD HH:mm [UTC]")}
                 </label>
               </td>
 

--- a/src/Components/History/EventItem.tsx
+++ b/src/Components/History/EventItem.tsx
@@ -124,7 +124,7 @@ export function EventItem({ Prev, Curr }: IEventItem) {
           {dayjs(Curr.Start).format("DD MMM, HH:mm")}
 
           {Curr.End && (
-            <> - {dayjs(Curr.End).format("DD MMM, HH:mm [UTC]")}</>
+            <> - {dayjs(Curr.End).utc().format("DD MMM, HH:mm [UTC]")}</>
           )}
         </label>
 

--- a/src/Components/Home/EventGrid.tsx
+++ b/src/Components/Home/EventGrid.tsx
@@ -112,9 +112,9 @@ export function EventGrid() {
         return [
           x.Id,
           [tag],
-          dayjs(x.Start).format("YYYY-MM-DD HH:mm [UTC]"),
+          dayjs(x.Start).utc().format("YYYY-MM-DD HH:mm [UTC]"),
           x.End
-            ? dayjs(x.End).format("MM-DD HH:mm")
+            ? dayjs(x.End).utc().format("MM-DD HH:mm")
             : x.Status,
           x.Regions.length > 1
             ? `${x.Regions[0]} +${x.Regions.length - 1}`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,9 +2,12 @@ import "@telekom/scale-components/dist/scale-components/scale-components.css";
 import "./index.css";
 
 import { defineCustomElements } from "@telekom/scale-components/loader";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 
+dayjs.extend(utc);
 defineCustomElements();
 
 const container = document.querySelector("#root")!;


### PR DESCRIPTION
## Summary of the Pull Request

When the event was created, it was explicitly stated to be CET.
this modification specifies that the time displayed as UTC is the correct UTC zone.