### PR TITLE
[fix] Update ServiceItem and refine event filtering logic

### DIFF
--- a/src/Components/Home/ServiceItem.tsx
+++ b/src/Components/Home/ServiceItem.tsx
@@ -15,7 +15,7 @@ interface IServiceItem {
 /**
  * @author Aloento
  * @since 1.0.0
- * @version 0.2.0
+ * @version 0.2.1
  */
 export function ServiceItem({ RegionService }: IServiceItem) {
   const { DB } = useStatus();
@@ -31,7 +31,7 @@ export function ServiceItem({ RegionService }: IServiceItem) {
           return false;
         }
 
-        return IsOpenStatus(x.Status);
+        return x.Type !== EventType.Information && IsOpenStatus(x.Status);
       })
       .orderBy(x => x.Type, 'desc')
       .head()


### PR DESCRIPTION
Updates ServiceItem version and refines event filtering

Increases the version number to 0.2.1 to reflect recent changes.

Refines the event filtering logic to exclude informational events while determining open status, improving the accuracy of the displayed service items.