### PR TITLE
[fix] Update end date field requirement based on event type

### DIFF
--- a/src/Components/Event/EventEditor.tsx
+++ b/src/Components/Event/EventEditor.tsx
@@ -98,7 +98,7 @@ export function EventEditor({ Event }: { Event: Models.IEvent }) {
         <ScaleTextField
           type="datetime-local"
           label="(Plan) End CET"
-          disabled={!(!IsIncident(State.type) || !IsOpenStatus(State.status))}
+          required={State.type === EventType.Maintenance}
           value={State.end ? dayjs(State.end).format(Dic.Picker) : null}
           onScale-input={(e) => Actions.setEnd(new Date(e.target.value as string))}
           invalid={!!Validation.end}

--- a/src/Components/New/NewForm.tsx
+++ b/src/Components/New/NewForm.tsx
@@ -138,7 +138,7 @@ export function NewForm() {
         <ScaleTextField
           type="datetime-local"
           label="(Plan) End CET"
-          required
+          required={State.type === EventType.Maintenance}
           value={State.end ? dayjs(State.end).format(Dic.Picker) : null}
           onScale-input={(e) => Actions.setEnd(new Date(e.target.value as string))}
           invalid={!!Validation.end}


### PR DESCRIPTION
Changes the requirement for the end date field in the event editor and new form to only be mandatory when the event type is Maintenance.

This improves user experience by ensuring that the field is conditionally required, preventing unnecessary errors for other event types.