### PR TITLE
[fix] Refactors event forms to improve type field handling

### DIFF
--- a/src/Components/Event/EventEditor.tsx
+++ b/src/Components/Event/EventEditor.tsx
@@ -40,6 +40,21 @@ export function EventEditor({ Event }: { Event: Models.IEvent }) {
       class="absolute"
       onScale-before-close={(e) => e.preventDefault()}
     >
+
+      <ScaleDropdownSelect
+        label="Type"
+        value={State.type}
+        disabled={!IsIncident(Event.Type)}
+        onScale-change={(e) => Actions.setType(e.target.value as EventType)}
+        invalid={!!Validation.type}
+        helperText={Validation.type}
+      >
+        {Object.values(EventType).slice(2, 5).map((type, i) =>
+          <ScaleDropdownSelectItem value={type} key={i}>
+            {type}
+          </ScaleDropdownSelectItem>)}
+      </ScaleDropdownSelect>
+
       <form
         className="flex flex-col gap-y-6"
         autoComplete="off"
@@ -56,20 +71,6 @@ export function EventEditor({ Event }: { Event: Models.IEvent }) {
           invalid={!!Validation.title}
           helperText={Validation.title}
         />
-
-        <ScaleDropdownSelect
-          label="Type"
-          value={State.type}
-          disabled={!IsIncident(Event.Type)}
-          onScale-change={(e) => Actions.setType(e.target.value as EventType)}
-          invalid={!!Validation.type}
-          helperText={Validation.type}
-        >
-          {Object.values(EventType).slice(2, 5).map((type, i) =>
-            <ScaleDropdownSelectItem value={type} key={i}>
-              {type}
-            </ScaleDropdownSelectItem>)}
-        </ScaleDropdownSelect>
 
         <ScaleDropdownSelect
           label="Status"

--- a/src/Components/New/NewForm.tsx
+++ b/src/Components/New/NewForm.tsx
@@ -36,15 +36,6 @@ export function NewForm() {
         OnSubmit();
       }}
     >
-      <ScaleTextField
-        placeholder="Please give the title of event"
-        required
-        label="Title"
-        value={State.title}
-        onScale-input={(e) => Actions.setTitle(e.target.value as string)}
-        invalid={!!Validation.title}
-        helperText={Validation.title}
-      />
 
       <ScaleDropdownSelect
         label="Type"
@@ -58,6 +49,16 @@ export function NewForm() {
             {type}
           </ScaleDropdownSelectItem>)}
       </ScaleDropdownSelect>
+
+      <ScaleTextField
+        placeholder="Please give the title of event"
+        required
+        label="Title"
+        value={State.title}
+        onScale-input={(e) => Actions.setTitle(e.target.value as string)}
+        invalid={!!Validation.title}
+        helperText={Validation.title}
+      />
 
       <ScaleTextarea
         placeholder="If there is any known information, please write it down here."


### PR DESCRIPTION
Updates the `EventEditor` and `NewForm` components by moving the title input field to a consistent position within the forms.

The title field is now rendered after the type dropdown in the `NewForm`, enhancing user experience by maintaining a clear structure.

Redundant code for the type dropdown in `EventEditor` has been removed to streamline the component.