### PR TITLE
[fix] Update description length validation to 500 characters

### DIFF
--- a/src/Components/New/useNewForm.ts
+++ b/src/Components/New/useNewForm.ts
@@ -70,8 +70,8 @@ export function useNewForm() {
   function setDescription(value = description) {
     let err: boolean = false;
 
-    if (value && (value.length < 10 || value.length > 200)) {
-      setValDescription("Description must be between 10 and 200 characters.");
+    if (value && (value.length < 10 || value.length > 500)) {
+      setValDescription("Description must be between 10 and 500 characters.");
       err = true;
     }
 


### PR DESCRIPTION
Increases the maximum allowed length for the description field from 200 to 500 characters to accommodate more detailed input.

This change addresses user feedback for enhanced flexibility in description length.