### PR TITLE
[fix] Restricts update date validation for non-maintenance events

### DIFF
--- a/src/Components/Event/useEditForm.ts
+++ b/src/Components/Event/useEditForm.ts
@@ -156,7 +156,7 @@ export function useEditForm(event: Models.IEvent) {
   function setUpdateAt(value = updateAt) {
     let err: boolean = false;
 
-    if (value && value < start) {
+    if (type !== EventType.Maintenance && value && value < start) {
       setValUpdateAt("Update Date cannot be earlier than Start Date.");
       err = true;
     }


### PR DESCRIPTION
Updates the update date validation logic to only enforce that the update date cannot be earlier than the start date for non-maintenance event types.

This change allows maintenance events to bypass this restriction, accommodating different scheduling needs.