### PR TITLE
[feat] Improves IndexedDB initialization and recovery

### DIFF
--- a/src/Services/DB.ts
+++ b/src/Services/DB.ts
@@ -1,36 +1,55 @@
-import { openDB } from "idb";
+import { deleteDB, openDB } from "idb";
 import { Dic } from "~/Helpers/Entities";
+
+const DB_VERSION = 2;
 
 /**
  * @author Aloento
  * @since 1.0.0
- * @version 0.1.0
+ * @version 0.2.0
  */
 export class DB<T> {
   public Ins: T;
+  private dbName: string;
+  private storeName: string;
 
   constructor(factory: () => T) {
     this.Ins = factory();
+    this.dbName = Dic.Name;
+    this.storeName = Dic.Name;
   }
 
   public async init() {
-    return openDB(Dic.Name, 1, {
-      upgrade(db) {
-        db.createObjectStore(Dic.Name);
-      },
-    });
+    try {
+      return openDB(this.dbName, DB_VERSION, {
+        upgrade(db) {
+          if (db.objectStoreNames.contains(Dic.Name)) {
+            db.deleteObjectStore(Dic.Name);
+          }
+          db.createObjectStore(Dic.Name);
+        },
+      });
+    } catch (error) {
+      await deleteDB(this.dbName);
+
+      return openDB(this.dbName, DB_VERSION, {
+        upgrade(db) {
+          db.createObjectStore(Dic.Name);
+        },
+      });
+    }
   }
 
   public async save(key: string, data = this.Ins) {
     this.Ins = data;
     const db = await this.init();
-    await db.put(Dic.Name, data, key);
+    await db.put(this.storeName, data, key);
     db.close();
   }
 
   public async load(key: string) {
     const db = await this.init();
-    const res = await db.get(Dic.Name, key) as T;
+    const res = await db.get(this.storeName, key) as T;
     if (res) {
       this.Ins = res;
     }


### PR DESCRIPTION
**Summary of the Pull Request:**

Adds explicit DB versioning and instance-level name fields, and strengthens upgrade logic to remove and recreate object stores to avoid conflicts. Catches open errors, deletes the database, and retries creation to recover from corrupted or incompatible DB states. Uses the instance store name for reads/writes to ensure consistent access and improve resilience during migrations.